### PR TITLE
adding google analytics tracking id

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,6 @@ callouts:
 
 # Google Analytics Tracking (optional)
 # Supports a CSV of tracking ID strings (eg. "UA-1234567-89,G-1AB234CDE5")
-# ga_tracking: UA-2709176-10
-# ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
+ga_tracking: UA-173086293-1
+ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 


### PR DESCRIPTION
- @laurenklun created google analytics account with comstock@nrel.gov
- and from the tracking id created for this account, added that id into the yml based on instruction shown [here](https://just-the-docs.github.io/just-the-docs/docs/configuration/#google-analytics)
- will later check if the webpage is being tracked by google analytics once merged to `main`